### PR TITLE
add weekly timed build, to keep image up2date

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,8 @@ on:
       - master
     tags:
       - 'v*'
+  schedule:
+    - cron: '42 23 * * 1'
 
 jobs:
   build:


### PR DESCRIPTION
In order to keep up with security management of the contained software, a periodic rebuild should be done.