### PR TITLE
feat: updates docker image

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -13,7 +13,7 @@ RUN cd /tmp && \
     cd /tmp/drawio/etc/build/ && \
     ant war
 
-FROM tomcat:9-jre11-slim
+FROM tomcat:9-jre11
 
 LABEL maintainer="JGraph Ltd"
 
@@ -39,10 +39,6 @@ RUN mkdir -p $CATALINA_HOME/webapps/draw && \
         -i '/Server/Service/Engine/Host/Context' -t 'attr' -n 'path' -v '/' \
         -i '/Server/Service/Engine/Host/Context[@path="/"]' -t 'attr' -n 'docBase' -v 'draw' \
         -s '/Server/Service/Engine/Host/Context[@path="/"]' -t 'elem' -n 'WatchedResource' -v 'WEB-INF/web.xml' \
-        -i '/Server/Service/Engine/Host/Valve' -t 'elem' -n 'Context' \
-        -i '/Server/Service/Engine/Host/Context[not(@path="/")]' -t 'attr' -n 'path' -v '/ROOT' \
-        -s '/Server/Service/Engine/Host/Context[@path="/ROOT"]' -t 'attr' -n 'docBase' -v 'ROOT' \
-        -s '/Server/Service/Engine/Host/Context[@path="/ROOT"]' -t 'elem' -n 'WatchedResource' -v 'WEB-INF/web.xml' \
         conf/server.xml
 
 # Copy docker-entrypoint


### PR DESCRIPTION
Refers #49 
Updates the docker image to a newer image
Tomcat does not provide a newer alpine image anymore, so it might be worth considering to deprecated the alpine container.

note: this removes the tomcat docs of the /ROOT path.