### PR TITLE
chore: add metadata annotations

### DIFF
--- a/image-export/Dockerfile
+++ b/image-export/Dockerfile
@@ -1,6 +1,9 @@
 FROM node:lts-slim
 
-LABEL maintainer="JGraph Ltd"
+LABEL maintainer="JGraph Ltd" \
+      org.opencontainers.image.authors="JGraph Ltd" \
+      org.opencontainers.image.url="https://www.drawio.com" \
+      org.opencontainers.image.source="https://github.com/jgraph/docker-drawio"
 
 ENV RUN_USER            drawio
 ENV RUN_GROUP           drawio

--- a/main/Dockerfile
+++ b/main/Dockerfile
@@ -15,7 +15,10 @@ RUN cd /tmp && \
 
 FROM tomcat:9-jre11
 
-LABEL maintainer="JGraph Ltd"
+LABEL maintainer="JGraph Ltd" \
+      org.opencontainers.image.authors="JGraph Ltd" \
+      org.opencontainers.image.url="https://www.drawio.com" \
+      org.opencontainers.image.source="https://github.com/jgraph/docker-drawio"
 
 ENV RUN_USER            tomcat
 ENV RUN_GROUP           tomcat


### PR DESCRIPTION
This adds some metadata via [OCI annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md). This helps consumers understand better where the images are coming from.