### PR TITLE
Configure Tomcat max header size through environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ If you're running `Docker Toolbox` then start a web browser session to <http://1
 * **COUNTRY_CODE**: Country code to be used as certificate "C" record; default `FR`
 * **KEYSTORE_PASS**: ".keystore"/.jks" store password; default `V3ry1nS3cur3P4ssw0rd`
 * **KEY_PASS**: Private key password; default `<ref:KEYSTORE_PASS>`
+* **TOMCAT_REQUEST_HEADER_LIMIT**: Request header limit for the Tomcat Server
 
 ## HTTPS SSL Certificate via Let's Encrypt
 

--- a/main/docker-entrypoint.sh
+++ b/main/docker-entrypoint.sh
@@ -58,6 +58,14 @@ if [ -n "$DRAWIO_SERVER_URL" ] && [ "$CONTEXT_PATH" != "/" ]; then
 else
   echo "Tomcat context remains at root '/'"
 fi
+
+# Update the maxHTTPHeaderSize in Tomcat for the HTTP endpoint
+echo "Updating Tomcat max header size to '${TOMCAT_REQUEST_HEADER_LIMIT:-8192}'"
+  xmlstarlet ed -P -S -L \
+    -i '/Server/Service/Connector[@port="8080"]' -t attr -n 'maxHttpHeaderSize' -v "${TOMCAT_REQUEST_HEADER_LIMIT:-8192}" \
+    conf/server.xml
+
+
 #DRAWIO_VIEWER_URL is path to the viewer js, e.g. https://www.example.com/js/viewer.min.js
 echo "window.DRAWIO_VIEWER_URL = '${DRAWIO_VIEWER_URL}';" >> $CATALINA_HOME/webapps/draw/js/PreConfig.js
 #DRAWIO_LIGHTBOX_URL Replace with your lightbox URL, eg. https://www.example.com
@@ -189,6 +197,7 @@ if [ -f $CATALINA_HOME/.keystore ] && [ -z $VAR ]; then
         -i "/Server/Service/${UUID}" -t 'attr' -n 'KeystoreFile' -v "$CATALINA_HOME/.keystore" \
         -i "/Server/Service/${UUID}" -t 'attr' -n 'KeystorePass' -v "${KEY_PASS}" \
         -i "/Server/Service/${UUID}" -t 'attr' -n 'defaultSSLHostConfigName' -v "${PUBLIC_DNS:-'draw.example.com'}" \
+        -i "/Server/Service/${UUID}" -t 'attr' -n 'maxHttpHeaderSize' -v "${TOMCAT_REQUEST_HEADER_LIMIT:-8192}" \
         -s "/Server/Service/${UUID}" -t 'elem' -n 'SSLHostConfig' \
         -i "/Server/Service/${UUID}/SSLHostConfig" -t 'attr' -n 'hostName' -v "${PUBLIC_DNS:-'draw.example.com'}" \
         -i "/Server/Service/${UUID}/SSLHostConfig" -t 'attr' -n 'protocols' -v 'TLSv1.2' \


### PR DESCRIPTION
- In some authentication scenario's in an Azure App, the request header limit in TOMcat is limiting functionality. 
This commit adds an environment variable that can be used to change this request limit size.