### PR TITLE
Add write permission to run_group on catalina_home

### DIFF
--- a/main/Dockerfile
+++ b/main/Dockerfile
@@ -53,7 +53,7 @@ COPY docker-entrypoint.sh /
 RUN chmod 755 /docker-entrypoint.sh
 # Add a tomcat user
 RUN groupadd -r ${RUN_GROUP} && useradd -g ${RUN_GROUP} -d ${CATALINA_HOME} -s /bin/bash ${RUN_USER} && \
-    chown -R ${RUN_USER}:${RUN_GROUP} ${CATALINA_HOME}
+    chown -R ${RUN_USER}:${RUN_GROUP} ${CATALINA_HOME} && chmod -R g+w ${CATALINA_HOME}
 
 USER ${RUN_USER}
 


### PR DESCRIPTION
This allow true rootless for kubernetes and docker-compose

Solution for kubernetes is adding:
```
spec:
  template:
    spec:
      containers:
        - name: drawio
      securityContext:
        supplementalGroups: [999]
```

Solution for docker-compose is adding:
```
services:
  drawio:
    group_add:
      - 999
```

Fixes #190
Fixes #186