### PR TITLE
pass DRAWIO_MSGRAPH_TENANT_ID to server

### DIFF
--- a/main/docker-entrypoint.sh
+++ b/main/docker-entrypoint.sh
@@ -107,6 +107,7 @@ else
 
     if [[ "${DRAWIO_MSGRAPH_TENANT_ID}" ]]; then
         echo "window.DRAWIO_MSGRAPH_TENANT_ID = '${DRAWIO_MSGRAPH_TENANT_ID}'; " >> $CATALINA_HOME/webapps/draw/js/PreConfig.js
+        echo -n "${DRAWIO_MSGRAPH_TENANT_ID}" > $CATALINA_HOME/webapps/draw/WEB-INF/msgraph_tenant_id
     fi
 fi
 


### PR DESCRIPTION
fix #204

DRAWIO_MSGRAPH_TENANT_ID isn't written to the tomcat path for the server to use