### PR TITLE
Fix typo in docker-entrypoint comment

### DIFF
--- a/main/docker-entrypoint.sh
+++ b/main/docker-entrypoint.sh
@@ -185,7 +185,7 @@ if ! [ -f $CATALINA_HOME/.keystore ] && [ "$LETS_ENCRYPT_ENABLED" == "false" ]; 
     keytool -list -keystore $CATALINA_HOME/.keystore -v -storepass "${KEYSTORE_PASS}"
 fi
 
-# Update SSL port configuration if it does'nt exists
+# Update SSL port configuration if it doesn't exist
 #
 UUID="$(cat /dev/urandom | tr -dc 'a-zA-Z' | fold -w 1 | head -n 1)$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 7 | head -n 1)"
 VAR=$(cat conf/server.xml | grep "$CATALINA_HOME/.keystore")


### PR DESCRIPTION
The following section on Docker Hub redirects users to read the `docker-entrypoint.sh` for the supported `DRAWIO_` variables:
https://hub.docker.com/r/jgraph/drawio#changing-diagramsnet-configuration

> Configuration is managed by DRAWIO_* environment variables. For a list of these variables, check the docker-entrypoint.sh file in the main directory. For example, these variables allow enabling integration with Google Drive, OneDrive, ...

While reading through the entrypoint file I noticed the typo, for which I created this pull request.